### PR TITLE
Fix the compilation of explicit template initialization using LLVM

### DIFF
--- a/Topi.cc
+++ b/Topi.cc
@@ -1503,9 +1503,9 @@ void CTopi<TLit, TUInd, Compress>::SetParallelData(unsigned threadId, std::funct
 	M_GetNextUnitClause = GetNextUnitClause;
 }
 
-template class CTopi<int32_t, uint32_t, false>;
-template class CTopi<int32_t, uint64_t, false>;
-template class CTopi<int32_t, uint64_t, true>;
+template class Topor::CTopi<int32_t, uint32_t, false>;
+template class Topor::CTopi<int32_t, uint64_t, false>;
+template class Topor::CTopi<int32_t, uint64_t, true>;
 
 /*
 * Future

--- a/TopiAsg.cc
+++ b/TopiAsg.cc
@@ -338,6 +338,6 @@ bool CTopi<TLit,TUInd,Compress>::TrailAssertConsistency()
 	return true;
 }
 
-template class CTopi<int32_t, uint32_t, false>;
-template class CTopi<int32_t, uint64_t, false>;
-template class CTopi<int32_t, uint64_t, true>;
+template class Topor::CTopi<int32_t, uint32_t, false>;
+template class Topor::CTopi<int32_t, uint64_t, false>;
+template class Topor::CTopi<int32_t, uint64_t, true>;

--- a/TopiBacktrack.cc
+++ b/TopiBacktrack.cc
@@ -58,6 +58,6 @@ void CTopi<TLit,TUInd,Compress>::Backtrack(TLit decLevelL, bool isBCPBacktrack, 
 	assert(NV(2) || !m_ParamReuseTrail || P(SReuseTrail()) + "\n");
 }
 
-template class CTopi<int32_t, uint32_t, false>;
-template class CTopi<int32_t, uint64_t, false>;
-template class CTopi<int32_t, uint64_t, true>;
+template class Topor::CTopi<int32_t, uint32_t, false>;
+template class Topor::CTopi<int32_t, uint64_t, false>;
+template class Topor::CTopi<int32_t, uint64_t, true>;

--- a/TopiBcp.cc
+++ b/TopiBcp.cc
@@ -859,6 +859,6 @@ bool CTopi<TLit, TUInd, Compress>::ProcessDelayedImplication(TULit diL, TULit ot
 	return false;
 }
 
-template class CTopi<int32_t, uint32_t, false>;
-template class CTopi<int32_t, uint64_t, false>;
-template class CTopi<int32_t, uint64_t, true>;
+template class Topor::CTopi<int32_t, uint32_t, false>;
+template class Topor::CTopi<int32_t, uint64_t, false>;
+template class Topor::CTopi<int32_t, uint64_t, true>;

--- a/TopiBitCompression.cc
+++ b/TopiBitCompression.cc
@@ -285,6 +285,6 @@ size_t CTopi<TLit, TUInd, Compress>::BCCapacitySum() const
 	return r;
 }
 
-template class CTopi<int32_t, uint32_t, false>;
-template class CTopi<int32_t, uint64_t, false>;
-template class CTopi<int32_t, uint64_t, true>;
+template class Topor::CTopi<int32_t, uint32_t, false>;
+template class Topor::CTopi<int32_t, uint64_t, false>;
+template class Topor::CTopi<int32_t, uint64_t, true>;

--- a/TopiCompression.cc
+++ b/TopiCompression.cc
@@ -1297,6 +1297,6 @@ void CTopi<TLit, TUInd, Compress>::CompressBuffersIfRequired()
 	assert(NV(2) || P("The trail: " + STrail() + "\n"));
 }
 
-template class CTopi<int32_t, uint32_t, false>;
-template class CTopi<int32_t, uint64_t, false>;
-template class CTopi<int32_t, uint64_t, true>;
+template class Topor::CTopi<int32_t, uint32_t, false>;
+template class Topor::CTopi<int32_t, uint64_t, false>;
+template class Topor::CTopi<int32_t, uint64_t, true>;

--- a/TopiConflictAnalysis.cc
+++ b/TopiConflictAnalysis.cc
@@ -1367,6 +1367,6 @@ void CTopi<TLit, TUInd, Compress>::MarkDecisionsInConeAsVisited(TULit triggering
 	assert(IsVisitedConsistent());
 }
 
-template class CTopi<int32_t, uint32_t, false>;
-template class CTopi<int32_t, uint64_t, false>;
-template class CTopi<int32_t, uint64_t, true>;
+template class Topor::CTopi<int32_t, uint32_t, false>;
+template class Topor::CTopi<int32_t, uint64_t, false>;
+template class Topor::CTopi<int32_t, uint64_t, true>;

--- a/TopiDebugPrinting.cc
+++ b/TopiDebugPrinting.cc
@@ -318,6 +318,6 @@ void CTopi<TLit, TUInd, Compress>::VerifyDebugModel()
 	cout << "VerifyDebugModel VERIFIED!\n";
 }
 
-template class CTopi<int32_t, uint32_t, false>;
-template class CTopi<int32_t, uint64_t, false>;
-template class CTopi<int32_t, uint64_t, true>;
+template class Topor::CTopi<int32_t, uint32_t, false>;
+template class Topor::CTopi<int32_t, uint64_t, false>;
+template class Topor::CTopi<int32_t, uint64_t, true>;

--- a/TopiDecision.cc
+++ b/TopiDecision.cc
@@ -175,6 +175,6 @@ void CTopi<TLit,TUInd,Compress>::UpdateScoreVar(TUVar v, double mult)
 	}
 }
 
-template class CTopi<int32_t, uint32_t, false>;
-template class CTopi<int32_t, uint64_t, false>;
-template class CTopi<int32_t, uint64_t, true>;
+template class Topor::CTopi<int32_t, uint32_t, false>;
+template class Topor::CTopi<int32_t, uint64_t, false>;
+template class Topor::CTopi<int32_t, uint64_t, true>;

--- a/TopiRestart.cc
+++ b/TopiRestart.cc
@@ -202,6 +202,6 @@ double CTopi<TLit,TUInd,Compress>::RestartLubySequence(double y, uint64_t x)
 	return pow(y, seq);
 }
 
-template class CTopi<int32_t, uint32_t, false>;
-template class CTopi<int32_t, uint64_t, false>;
-template class CTopi<int32_t, uint64_t, true>;
+template class Topor::CTopi<int32_t, uint32_t, false>;
+template class Topor::CTopi<int32_t, uint64_t, false>;
+template class Topor::CTopi<int32_t, uint64_t, true>;

--- a/TopiWL.cc
+++ b/TopiWL.cc
@@ -648,6 +648,6 @@ bool CTopi<TLit, TUInd, Compress>::WLIsLitBetter(TULit lCand, TULit lOther) cons
 	}
 }
 
-template class CTopi<int32_t, uint32_t, false>;
-template class CTopi<int32_t, uint64_t, false>;
-template class CTopi<int32_t, uint64_t, true>;
+template class Topor::CTopi<int32_t, uint32_t, false>;
+template class Topor::CTopi<int32_t, uint64_t, false>;
+template class Topor::CTopi<int32_t, uint64_t, true>;

--- a/Topor.cc
+++ b/Topor.cc
@@ -188,6 +188,6 @@ namespace Topor
 	}
 }
 
-template class CTopor<int32_t, uint32_t, false>;
-template class CTopor<int32_t, uint64_t, false>;
-template class CTopor<int32_t, uint64_t, true>;
+template class Topor::CTopor<int32_t, uint32_t, false>;
+template class Topor::CTopor<int32_t, uint64_t, false>;
+template class Topor::CTopor<int32_t, uint64_t, true>;


### PR DESCRIPTION
When trying to compile Intel SAT using LLVM I ran into many of the following error messages:

```
intel_sat/TopiWL.cc:653:16: error: explicit instantiation of 'Topor::CTopi' must occur in namespace 'Topor'
  template class CTopi<int32_t, uint64_t, true>;
                 ^
  intel_sat/Topi.hpp:55:8: note: explicit instantiation refers here
          class CTopi
                ^
  intel_sat/TopiWL.cc:653:16: note: in instantiation of member function 'Topor::CTopi<int, unsigned long long, true>::SetStatus' requested here
  template class CTopi<int32_t, uint64_t, true>;
```

As I understand it the namespace must be included in these explicit template initialisations according to the C++ standard, but GCC still accepts it: https://docwiki.embarcadero.com/RADStudio/Alexandria/en/Explicit_instantiation_of_%27namespace::templated_class%27_must_occur_in_namespace_%27namespace%27_(C%2B%2B)

This PR just adds the `Topor::` namespace to the `template class ...` statements