### PR TITLE
Fix cstdint dependency in ToporExternalTypes.hpp

### DIFF
--- a/ToporExternalTypes.hpp
+++ b/ToporExternalTypes.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <functional>
 #include "ColorPrint.h"
 


### PR DESCRIPTION
On g++ 13.2.1 this file didn't compile as it was missing definitions of the int types. I suspect in other versions of libstdc++ cstdint was included transitively through other headers but is no longer.